### PR TITLE
chore: signer: add support for encoding fixed sized arrays for primitive and custom types.

### DIFF
--- a/signer/core/apitypes/testdata/typed-data.json
+++ b/signer/core/apitypes/testdata/typed-data.json
@@ -1,0 +1,2511 @@
+[
+  {
+    "name": "random",
+    "typedData": {
+      "domain": {
+        "name": "Moo é🚀ooéééMooooM🚀 o🚀🚀o  M  oM🚀éo 🚀🚀🚀🚀éoMoéo🚀o",
+        "version": "28.44.13"
+      },
+      "primaryType": "Struct3",
+      "types": {
+        "Struct3": [
+          {
+            "name": "param2",
+            "type": "bytes"
+          }
+        ],
+        "EIP712Domain": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "type": "string"
+          }
+        ]
+      },
+      "message": {
+        "param2": "0xdce44ca98616ee629199215ae5401c97040664637c48"
+      }
+    },
+    "domainHash":  "0x5c1981928d4d666edf1272919eb6a19c63d02affc23c89202ced482a84760517",
+    "messageHash": "0xe8026963fde09e724c324e32fc7889cf27d5c57010f0a3a9cb9a4b1c5000fc58",
+    "digest": "0xf1a2769507736a9aa306204169e6862f4416e055035d7d2cc9ab6f1921604905"
+  },
+  {
+    "name": "non-array",
+    "typedData": {
+      "domain": {
+        "name": "ImmutableSeaport",
+        "version": "1.5",
+        "chainId": 31337,
+        "verifyingContract": "0x3870289A34bba912a05B2c0503F7484dD18d2f6F"
+      },
+      "primaryType": "OrderComponents",
+      "types": {
+        "OrderComponents": [
+          {
+            "name": "offerer",
+            "type": "address"
+          },
+          {
+            "name": "zone",
+            "type": "address"
+          },
+          {
+            "name": "offer",
+            "type": "OfferItem[]"
+          },
+          {
+            "name": "consideration",
+            "type": "ConsiderationItem[]"
+          },
+          {
+            "name": "orderType",
+            "type": "uint8"
+          },
+          {
+            "name": "startTime",
+            "type": "uint256"
+          },
+          {
+            "name": "endTime",
+            "type": "uint256"
+          },
+          {
+            "name": "zoneHash",
+            "type": "bytes32"
+          },
+          {
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "name": "conduitKey",
+            "type": "bytes32"
+          },
+          {
+            "name": "counter",
+            "type": "uint256"
+          }
+        ],
+        "OfferItem": [
+          {
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "name": "identifierOrCriteria",
+            "type": "uint256"
+          },
+          {
+            "name": "startAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "endAmount",
+            "type": "uint256"
+          }
+        ],
+        "ConsiderationItem": [
+          {
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "name": "identifierOrCriteria",
+            "type": "uint256"
+          },
+          {
+            "name": "startAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "endAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "recipient",
+            "type": "address"
+          }
+        ],
+        "EIP712Domain": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "type": "string"
+          },
+          {
+            "name": "chainId",
+            "type": "uint256"
+          },
+          {
+            "name": "verifyingContract",
+            "type": "address"
+          }
+        ]
+      },
+      "message": {
+        "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+        "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+        "offer": [
+          {
+            "itemType": "2",
+            "token": "0xa62835d1a6bf5f521c4e2746e1f51c923b8f3483",
+            "identifierOrCriteria": "0",
+            "startAmount": "1",
+            "endAmount": "1"
+          }
+        ],
+        "consideration": [
+          {
+            "itemType": "0",
+            "token": "0x0000000000000000000000000000000000000000",
+            "identifierOrCriteria": "0",
+            "startAmount": "1000000",
+            "endAmount": "1000000",
+            "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+          }
+        ],
+        "orderType": "2",
+        "startTime": "1721370485",
+        "endTime": "1784442485",
+        "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "salt": "0xd23957f29d709c45",
+        "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "counter": "0"
+      }
+    },
+    "domainHash":  "0x94c78e94e233546655365725a17a437f48bb870b898e35b894da4a0887172dc2",
+    "messageHash": "0x81203a474f76afd1376c9f00b3947b5b7e89a73b13b165f999d540377bb1c2fb",
+    "digest": "0x09311d5cc4e0d26af26c78438f55094fdf489083cd75223073db9a0a5da22b84"
+  },
+  {
+    "name": "single-dimension-fixed-size-array",
+    "typedData": {
+      "domain": {
+        "name": "ImmutableSeaport",
+        "version": "1.5",
+        "chainId": 31337,
+        "verifyingContract": "0x3870289A34bba912a05B2c0503F7484dD18d2f6F"
+      },
+      "primaryType": "BulkOrder",
+      "types": {
+        "BulkOrder": [
+          {
+            "name": "tree",
+            "type": "OrderComponents[2]"
+          }
+        ],
+        "OrderComponents": [
+          {
+            "name": "offerer",
+            "type": "address"
+          },
+          {
+            "name": "zone",
+            "type": "address"
+          },
+          {
+            "name": "offer",
+            "type": "OfferItem[]"
+          },
+          {
+            "name": "consideration",
+            "type": "ConsiderationItem[]"
+          },
+          {
+            "name": "orderType",
+            "type": "uint8"
+          },
+          {
+            "name": "startTime",
+            "type": "uint256"
+          },
+          {
+            "name": "endTime",
+            "type": "uint256"
+          },
+          {
+            "name": "zoneHash",
+            "type": "bytes32"
+          },
+          {
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "name": "conduitKey",
+            "type": "bytes32"
+          },
+          {
+            "name": "counter",
+            "type": "uint256"
+          }
+        ],
+        "OfferItem": [
+          {
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "name": "identifierOrCriteria",
+            "type": "uint256"
+          },
+          {
+            "name": "startAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "endAmount",
+            "type": "uint256"
+          }
+        ],
+        "ConsiderationItem": [
+          {
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "name": "identifierOrCriteria",
+            "type": "uint256"
+          },
+          {
+            "name": "startAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "endAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "recipient",
+            "type": "address"
+          }
+        ],
+        "EIP712Domain": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "type": "string"
+          },
+          {
+            "name": "chainId",
+            "type": "uint256"
+          },
+          {
+            "name": "verifyingContract",
+            "type": "address"
+          }
+        ]
+      },
+      "message": {
+        "tree": [
+          {
+            "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+            "offer": [
+              {
+                "itemType": "2",
+                "token": "0x262e2b50219620226c5fb5956432a88fffd94ba7",
+                "identifierOrCriteria": "0",
+                "startAmount": "1",
+                "endAmount": "1"
+              }
+            ],
+            "consideration": [
+              {
+                "itemType": "0",
+                "token": "0x0000000000000000000000000000000000000000",
+                "identifierOrCriteria": "0",
+                "startAmount": "1000000",
+                "endAmount": "1000000",
+                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+              }
+            ],
+            "orderType": "2",
+            "startTime": "1721370489",
+            "endTime": "1784442489",
+            "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "salt": "0x61bc238c47087001",
+            "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "counter": "0"
+          },
+          {
+            "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+            "offer": [
+              {
+                "itemType": "2",
+                "token": "0x262e2b50219620226c5fb5956432a88fffd94ba7",
+                "identifierOrCriteria": "1",
+                "startAmount": "1",
+                "endAmount": "1"
+              }
+            ],
+            "consideration": [
+              {
+                "itemType": "0",
+                "token": "0x0000000000000000000000000000000000000000",
+                "identifierOrCriteria": "0",
+                "startAmount": "1000000",
+                "endAmount": "1000000",
+                "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+              }
+            ],
+            "orderType": "2",
+            "startTime": "1721370489",
+            "endTime": "1784442489",
+            "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "salt": "0x9bf89a1fed29e323",
+            "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "counter": "0"
+          }
+        ]
+      }
+    },
+    "domainHash":  "0x94c78e94e233546655365725a17a437f48bb870b898e35b894da4a0887172dc2",
+    "messageHash": "0x449764b1b6c14b5c3d2b69ca5f112e4172feefc49d9712be588862d606d82552",
+    "digest": "0xa51998e192ae3b3f551e481205b3e84f47041cd1fdccc6ebeb84d09dbaa9163c"
+  },
+  {
+    "name": "two-dimensional-fixed-size-array",
+    "typedData": {
+      "domain": {
+        "name": "ImmutableSeaport",
+        "version": "1.5",
+        "chainId": 31337,
+        "verifyingContract": "0x3870289A34bba912a05B2c0503F7484dD18d2f6F"
+      },
+      "primaryType": "BulkOrder",
+      "types": {
+        "BulkOrder": [
+          {
+            "name": "tree",
+            "type": "OrderComponents[2][2]"
+          }
+        ],
+        "OrderComponents": [
+          {
+            "name": "offerer",
+            "type": "address"
+          },
+          {
+            "name": "zone",
+            "type": "address"
+          },
+          {
+            "name": "offer",
+            "type": "OfferItem[]"
+          },
+          {
+            "name": "consideration",
+            "type": "ConsiderationItem[]"
+          },
+          {
+            "name": "orderType",
+            "type": "uint8"
+          },
+          {
+            "name": "startTime",
+            "type": "uint256"
+          },
+          {
+            "name": "endTime",
+            "type": "uint256"
+          },
+          {
+            "name": "zoneHash",
+            "type": "bytes32"
+          },
+          {
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "name": "conduitKey",
+            "type": "bytes32"
+          },
+          {
+            "name": "counter",
+            "type": "uint256"
+          }
+        ],
+        "OfferItem": [
+          {
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "name": "identifierOrCriteria",
+            "type": "uint256"
+          },
+          {
+            "name": "startAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "endAmount",
+            "type": "uint256"
+          }
+        ],
+        "ConsiderationItem": [
+          {
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "name": "identifierOrCriteria",
+            "type": "uint256"
+          },
+          {
+            "name": "startAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "endAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "recipient",
+            "type": "address"
+          }
+        ],
+        "EIP712Domain": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "type": "string"
+          },
+          {
+            "name": "chainId",
+            "type": "uint256"
+          },
+          {
+            "name": "verifyingContract",
+            "type": "address"
+          }
+        ]
+      },
+      "message": {
+        "tree": [
+          [
+            {
+              "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+              "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+              "offer": [
+                {
+                  "itemType": "2",
+                  "token": "0x06b3244b086cecc40f1e5a826f736ded68068a0f",
+                  "identifierOrCriteria": "0",
+                  "startAmount": "1",
+                  "endAmount": "1"
+                }
+              ],
+              "consideration": [
+                {
+                  "itemType": "0",
+                  "token": "0x0000000000000000000000000000000000000000",
+                  "identifierOrCriteria": "0",
+                  "startAmount": "1000000",
+                  "endAmount": "1000000",
+                  "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                }
+              ],
+              "orderType": "2",
+              "startTime": "1721370492",
+              "endTime": "1784442492",
+              "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "salt": "0x143555bae9f6c3dd",
+              "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "counter": "0"
+            },
+            {
+              "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+              "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+              "offer": [
+                {
+                  "itemType": "2",
+                  "token": "0x06b3244b086cecc40f1e5a826f736ded68068a0f",
+                  "identifierOrCriteria": "1",
+                  "startAmount": "1",
+                  "endAmount": "1"
+                }
+              ],
+              "consideration": [
+                {
+                  "itemType": "0",
+                  "token": "0x0000000000000000000000000000000000000000",
+                  "identifierOrCriteria": "0",
+                  "startAmount": "1000000",
+                  "endAmount": "1000000",
+                  "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                }
+              ],
+              "orderType": "2",
+              "startTime": "1721370492",
+              "endTime": "1784442492",
+              "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "salt": "0xa40e43309562a29b",
+              "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "counter": "0"
+            }
+          ],
+          [
+            {
+              "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+              "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+              "offer": [
+                {
+                  "itemType": "2",
+                  "token": "0x06b3244b086cecc40f1e5a826f736ded68068a0f",
+                  "identifierOrCriteria": "2",
+                  "startAmount": "1",
+                  "endAmount": "1"
+                }
+              ],
+              "consideration": [
+                {
+                  "itemType": "0",
+                  "token": "0x0000000000000000000000000000000000000000",
+                  "identifierOrCriteria": "0",
+                  "startAmount": "1000000",
+                  "endAmount": "1000000",
+                  "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                }
+              ],
+              "orderType": "2",
+              "startTime": "1721370492",
+              "endTime": "1784442492",
+              "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "salt": "0x43ef498909096747",
+              "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "counter": "0"
+            },
+            {
+              "offerer": "0x0000000000000000000000000000000000000000",
+              "zone": "0x0000000000000000000000000000000000000000",
+              "offer": [],
+              "consideration": [],
+              "orderType": "0",
+              "startTime": "0",
+              "endTime": "0",
+              "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "salt": "0",
+              "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "counter": "0"
+            }
+          ]
+        ]
+      }
+    },
+    "domainHash":  "0x94c78e94e233546655365725a17a437f48bb870b898e35b894da4a0887172dc2",
+    "messageHash": "0x369514af6e781a85186ef2c059e0d9e7b14e5d58a95970655794439eca7f3f7e",
+    "digest": "0x42554635de2cd114d9e36535d7890e93525faa924af52182ae72c069c4909de6"
+  },
+  {
+    "name": "three-dimensional-fixed-size-array",
+    "typedData": {
+      "domain": {
+        "name": "ImmutableSeaport",
+        "version": "1.5",
+        "chainId": 31337,
+        "verifyingContract": "0x3870289A34bba912a05B2c0503F7484dD18d2f6F"
+      },
+      "primaryType": "BulkOrder",
+      "types": {
+        "BulkOrder": [
+          {
+            "name": "tree",
+            "type": "OrderComponents[2][2][2]"
+          }
+        ],
+        "OrderComponents": [
+          {
+            "name": "offerer",
+            "type": "address"
+          },
+          {
+            "name": "zone",
+            "type": "address"
+          },
+          {
+            "name": "offer",
+            "type": "OfferItem[]"
+          },
+          {
+            "name": "consideration",
+            "type": "ConsiderationItem[]"
+          },
+          {
+            "name": "orderType",
+            "type": "uint8"
+          },
+          {
+            "name": "startTime",
+            "type": "uint256"
+          },
+          {
+            "name": "endTime",
+            "type": "uint256"
+          },
+          {
+            "name": "zoneHash",
+            "type": "bytes32"
+          },
+          {
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "name": "conduitKey",
+            "type": "bytes32"
+          },
+          {
+            "name": "counter",
+            "type": "uint256"
+          }
+        ],
+        "OfferItem": [
+          {
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "name": "identifierOrCriteria",
+            "type": "uint256"
+          },
+          {
+            "name": "startAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "endAmount",
+            "type": "uint256"
+          }
+        ],
+        "ConsiderationItem": [
+          {
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "name": "identifierOrCriteria",
+            "type": "uint256"
+          },
+          {
+            "name": "startAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "endAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "recipient",
+            "type": "address"
+          }
+        ],
+        "EIP712Domain": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "type": "string"
+          },
+          {
+            "name": "chainId",
+            "type": "uint256"
+          },
+          {
+            "name": "verifyingContract",
+            "type": "address"
+          }
+        ]
+      },
+      "message": {
+        "tree": [
+          [
+            [
+              {
+                "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                "offer": [
+                  {
+                    "itemType": "2",
+                    "token": "0x2f8d338360d095a72680a943a22fe6a0d398a0b4",
+                    "identifierOrCriteria": "0",
+                    "startAmount": "1",
+                    "endAmount": "1"
+                  }
+                ],
+                "consideration": [
+                  {
+                    "itemType": "0",
+                    "token": "0x0000000000000000000000000000000000000000",
+                    "identifierOrCriteria": "0",
+                    "startAmount": "1000000",
+                    "endAmount": "1000000",
+                    "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                  }
+                ],
+                "orderType": "2",
+                "startTime": "1721798594",
+                "endTime": "1784870594",
+                "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "salt": "0xea6603a0f70fa487",
+                "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "counter": "0"
+              },
+              {
+                "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                "offer": [
+                  {
+                    "itemType": "2",
+                    "token": "0x2f8d338360d095a72680a943a22fe6a0d398a0b4",
+                    "identifierOrCriteria": "1",
+                    "startAmount": "1",
+                    "endAmount": "1"
+                  }
+                ],
+                "consideration": [
+                  {
+                    "itemType": "0",
+                    "token": "0x0000000000000000000000000000000000000000",
+                    "identifierOrCriteria": "0",
+                    "startAmount": "1000000",
+                    "endAmount": "1000000",
+                    "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                  }
+                ],
+                "orderType": "2",
+                "startTime": "1721798594",
+                "endTime": "1784870594",
+                "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "salt": "0x5e5926d7394ebc15",
+                "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "counter": "0"
+              }
+            ],
+            [
+              {
+                "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                "offer": [
+                  {
+                    "itemType": "2",
+                    "token": "0x2f8d338360d095a72680a943a22fe6a0d398a0b4",
+                    "identifierOrCriteria": "2",
+                    "startAmount": "1",
+                    "endAmount": "1"
+                  }
+                ],
+                "consideration": [
+                  {
+                    "itemType": "0",
+                    "token": "0x0000000000000000000000000000000000000000",
+                    "identifierOrCriteria": "0",
+                    "startAmount": "1000000",
+                    "endAmount": "1000000",
+                    "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                  }
+                ],
+                "orderType": "2",
+                "startTime": "1721798594",
+                "endTime": "1784870594",
+                "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "salt": "0xecb78d6939c73069",
+                "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "counter": "0"
+              },
+              {
+                "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                "offer": [
+                  {
+                    "itemType": "2",
+                    "token": "0x2f8d338360d095a72680a943a22fe6a0d398a0b4",
+                    "identifierOrCriteria": "3",
+                    "startAmount": "1",
+                    "endAmount": "1"
+                  }
+                ],
+                "consideration": [
+                  {
+                    "itemType": "0",
+                    "token": "0x0000000000000000000000000000000000000000",
+                    "identifierOrCriteria": "0",
+                    "startAmount": "1000000",
+                    "endAmount": "1000000",
+                    "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                  }
+                ],
+                "orderType": "2",
+                "startTime": "1721798594",
+                "endTime": "1784870594",
+                "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "salt": "0xb468f60676944382",
+                "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "counter": "0"
+              }
+            ]
+          ],
+          [
+            [
+              {
+                "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                "offer": [
+                  {
+                    "itemType": "2",
+                    "token": "0x2f8d338360d095a72680a943a22fe6a0d398a0b4",
+                    "identifierOrCriteria": "4",
+                    "startAmount": "1",
+                    "endAmount": "1"
+                  }
+                ],
+                "consideration": [
+                  {
+                    "itemType": "0",
+                    "token": "0x0000000000000000000000000000000000000000",
+                    "identifierOrCriteria": "0",
+                    "startAmount": "1000000",
+                    "endAmount": "1000000",
+                    "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                  }
+                ],
+                "orderType": "2",
+                "startTime": "1721798594",
+                "endTime": "1784870594",
+                "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "salt": "0x84e6227b4e60e915",
+                "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "counter": "0"
+              },
+              {
+                "offerer": "0x0000000000000000000000000000000000000000",
+                "zone": "0x0000000000000000000000000000000000000000",
+                "offer": [],
+                "consideration": [],
+                "orderType": "0",
+                "startTime": "0",
+                "endTime": "0",
+                "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "salt": "0",
+                "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "counter": "0"
+              }
+            ],
+            [
+              {
+                "offerer": "0x0000000000000000000000000000000000000000",
+                "zone": "0x0000000000000000000000000000000000000000",
+                "offer": [],
+                "consideration": [],
+                "orderType": "0",
+                "startTime": "0",
+                "endTime": "0",
+                "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "salt": "0",
+                "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "counter": "0"
+              },
+              {
+                "offerer": "0x0000000000000000000000000000000000000000",
+                "zone": "0x0000000000000000000000000000000000000000",
+                "offer": [],
+                "consideration": [],
+                "orderType": "0",
+                "startTime": "0",
+                "endTime": "0",
+                "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "salt": "0",
+                "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "counter": "0"
+              }
+            ]
+          ]
+        ]
+      }
+    },
+    "domainHash":  "0x94c78e94e233546655365725a17a437f48bb870b898e35b894da4a0887172dc2",
+    "messageHash": "0xb5676629424954a09bd2aea49194741ea05d9525153b062b4507b45c7a0ad759",
+    "digest": "0xba39e9b22ff1ecd70a6ca86875a8c28e8c3f638d089071edaf97c1e4b6b072a0"
+  },
+  {
+    "name": "four-dimensional-fixed-size-array",
+    "typedData": {
+      "domain": {
+        "name": "ImmutableSeaport",
+        "version": "1.5",
+        "chainId": 31337,
+        "verifyingContract": "0x3870289A34bba912a05B2c0503F7484dD18d2f6F"
+      },
+      "primaryType": "BulkOrder",
+      "types": {
+        "BulkOrder": [
+          {
+            "name": "tree",
+            "type": "OrderComponents[2][2][2][2]"
+          }
+        ],
+        "OrderComponents": [
+          {
+            "name": "offerer",
+            "type": "address"
+          },
+          {
+            "name": "zone",
+            "type": "address"
+          },
+          {
+            "name": "offer",
+            "type": "OfferItem[]"
+          },
+          {
+            "name": "consideration",
+            "type": "ConsiderationItem[]"
+          },
+          {
+            "name": "orderType",
+            "type": "uint8"
+          },
+          {
+            "name": "startTime",
+            "type": "uint256"
+          },
+          {
+            "name": "endTime",
+            "type": "uint256"
+          },
+          {
+            "name": "zoneHash",
+            "type": "bytes32"
+          },
+          {
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "name": "conduitKey",
+            "type": "bytes32"
+          },
+          {
+            "name": "counter",
+            "type": "uint256"
+          }
+        ],
+        "OfferItem": [
+          {
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "name": "identifierOrCriteria",
+            "type": "uint256"
+          },
+          {
+            "name": "startAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "endAmount",
+            "type": "uint256"
+          }
+        ],
+        "ConsiderationItem": [
+          {
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "name": "identifierOrCriteria",
+            "type": "uint256"
+          },
+          {
+            "name": "startAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "endAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "recipient",
+            "type": "address"
+          }
+        ],
+        "EIP712Domain": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "type": "string"
+          },
+          {
+            "name": "chainId",
+            "type": "uint256"
+          },
+          {
+            "name": "verifyingContract",
+            "type": "address"
+          }
+        ]
+      },
+      "message": {
+        "tree": [
+          [
+            [
+              [
+                {
+                  "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                  "offer": [
+                    {
+                      "itemType": "2",
+                      "token": "0xc1eed9232a0a44c2463acb83698c162966fbc78d",
+                      "identifierOrCriteria": "0",
+                      "startAmount": "1",
+                      "endAmount": "1"
+                    }
+                  ],
+                  "consideration": [
+                    {
+                      "itemType": "0",
+                      "token": "0x0000000000000000000000000000000000000000",
+                      "identifierOrCriteria": "0",
+                      "startAmount": "1000000",
+                      "endAmount": "1000000",
+                      "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                    }
+                  ],
+                  "orderType": "2",
+                  "startTime": "1721798609",
+                  "endTime": "1784870609",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0x0aea7fa399421d03",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                },
+                {
+                  "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                  "offer": [
+                    {
+                      "itemType": "2",
+                      "token": "0xc1eed9232a0a44c2463acb83698c162966fbc78d",
+                      "identifierOrCriteria": "1",
+                      "startAmount": "1",
+                      "endAmount": "1"
+                    }
+                  ],
+                  "consideration": [
+                    {
+                      "itemType": "0",
+                      "token": "0x0000000000000000000000000000000000000000",
+                      "identifierOrCriteria": "0",
+                      "startAmount": "1000000",
+                      "endAmount": "1000000",
+                      "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                    }
+                  ],
+                  "orderType": "2",
+                  "startTime": "1721798609",
+                  "endTime": "1784870609",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0x547bf138eb02083d",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                }
+              ],
+              [
+                {
+                  "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                  "offer": [
+                    {
+                      "itemType": "2",
+                      "token": "0xc1eed9232a0a44c2463acb83698c162966fbc78d",
+                      "identifierOrCriteria": "2",
+                      "startAmount": "1",
+                      "endAmount": "1"
+                    }
+                  ],
+                  "consideration": [
+                    {
+                      "itemType": "0",
+                      "token": "0x0000000000000000000000000000000000000000",
+                      "identifierOrCriteria": "0",
+                      "startAmount": "1000000",
+                      "endAmount": "1000000",
+                      "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                    }
+                  ],
+                  "orderType": "2",
+                  "startTime": "1721798609",
+                  "endTime": "1784870609",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0x1fdc5cf73c2846",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                },
+                {
+                  "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                  "offer": [
+                    {
+                      "itemType": "2",
+                      "token": "0xc1eed9232a0a44c2463acb83698c162966fbc78d",
+                      "identifierOrCriteria": "3",
+                      "startAmount": "1",
+                      "endAmount": "1"
+                    }
+                  ],
+                  "consideration": [
+                    {
+                      "itemType": "0",
+                      "token": "0x0000000000000000000000000000000000000000",
+                      "identifierOrCriteria": "0",
+                      "startAmount": "1000000",
+                      "endAmount": "1000000",
+                      "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                    }
+                  ],
+                  "orderType": "2",
+                  "startTime": "1721798609",
+                  "endTime": "1784870609",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0x982c1f45640e7238",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                }
+              ]
+            ],
+            [
+              [
+                {
+                  "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                  "offer": [
+                    {
+                      "itemType": "2",
+                      "token": "0xc1eed9232a0a44c2463acb83698c162966fbc78d",
+                      "identifierOrCriteria": "4",
+                      "startAmount": "1",
+                      "endAmount": "1"
+                    }
+                  ],
+                  "consideration": [
+                    {
+                      "itemType": "0",
+                      "token": "0x0000000000000000000000000000000000000000",
+                      "identifierOrCriteria": "0",
+                      "startAmount": "1000000",
+                      "endAmount": "1000000",
+                      "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                    }
+                  ],
+                  "orderType": "2",
+                  "startTime": "1721798609",
+                  "endTime": "1784870609",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0x52438c99a8a41726",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                },
+                {
+                  "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                  "offer": [
+                    {
+                      "itemType": "2",
+                      "token": "0xc1eed9232a0a44c2463acb83698c162966fbc78d",
+                      "identifierOrCriteria": "5",
+                      "startAmount": "1",
+                      "endAmount": "1"
+                    }
+                  ],
+                  "consideration": [
+                    {
+                      "itemType": "0",
+                      "token": "0x0000000000000000000000000000000000000000",
+                      "identifierOrCriteria": "0",
+                      "startAmount": "1000000",
+                      "endAmount": "1000000",
+                      "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                    }
+                  ],
+                  "orderType": "2",
+                  "startTime": "1721798609",
+                  "endTime": "1784870609",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0x17a2c2cca1c84c21",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                }
+              ],
+              [
+                {
+                  "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                  "offer": [
+                    {
+                      "itemType": "2",
+                      "token": "0xc1eed9232a0a44c2463acb83698c162966fbc78d",
+                      "identifierOrCriteria": "6",
+                      "startAmount": "1",
+                      "endAmount": "1"
+                    }
+                  ],
+                  "consideration": [
+                    {
+                      "itemType": "0",
+                      "token": "0x0000000000000000000000000000000000000000",
+                      "identifierOrCriteria": "0",
+                      "startAmount": "1000000",
+                      "endAmount": "1000000",
+                      "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                    }
+                  ],
+                  "orderType": "2",
+                  "startTime": "1721798609",
+                  "endTime": "1784870609",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0xad92568ed1ac612a",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                },
+                {
+                  "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                  "offer": [
+                    {
+                      "itemType": "2",
+                      "token": "0xc1eed9232a0a44c2463acb83698c162966fbc78d",
+                      "identifierOrCriteria": "7",
+                      "startAmount": "1",
+                      "endAmount": "1"
+                    }
+                  ],
+                  "consideration": [
+                    {
+                      "itemType": "0",
+                      "token": "0x0000000000000000000000000000000000000000",
+                      "identifierOrCriteria": "0",
+                      "startAmount": "1000000",
+                      "endAmount": "1000000",
+                      "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                    }
+                  ],
+                  "orderType": "2",
+                  "startTime": "1721798609",
+                  "endTime": "1784870609",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0x1d72b3b8d1dfd249",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                {
+                  "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                  "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                  "offer": [
+                    {
+                      "itemType": "2",
+                      "token": "0xc1eed9232a0a44c2463acb83698c162966fbc78d",
+                      "identifierOrCriteria": "8",
+                      "startAmount": "1",
+                      "endAmount": "1"
+                    }
+                  ],
+                  "consideration": [
+                    {
+                      "itemType": "0",
+                      "token": "0x0000000000000000000000000000000000000000",
+                      "identifierOrCriteria": "0",
+                      "startAmount": "1000000",
+                      "endAmount": "1000000",
+                      "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                    }
+                  ],
+                  "orderType": "2",
+                  "startTime": "1721798609",
+                  "endTime": "1784870609",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0x03834e51be5d84bf",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                },
+                {
+                  "offerer": "0x0000000000000000000000000000000000000000",
+                  "zone": "0x0000000000000000000000000000000000000000",
+                  "offer": [],
+                  "consideration": [],
+                  "orderType": "0",
+                  "startTime": "0",
+                  "endTime": "0",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                }
+              ],
+              [
+                {
+                  "offerer": "0x0000000000000000000000000000000000000000",
+                  "zone": "0x0000000000000000000000000000000000000000",
+                  "offer": [],
+                  "consideration": [],
+                  "orderType": "0",
+                  "startTime": "0",
+                  "endTime": "0",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                },
+                {
+                  "offerer": "0x0000000000000000000000000000000000000000",
+                  "zone": "0x0000000000000000000000000000000000000000",
+                  "offer": [],
+                  "consideration": [],
+                  "orderType": "0",
+                  "startTime": "0",
+                  "endTime": "0",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                }
+              ]
+            ],
+            [
+              [
+                {
+                  "offerer": "0x0000000000000000000000000000000000000000",
+                  "zone": "0x0000000000000000000000000000000000000000",
+                  "offer": [],
+                  "consideration": [],
+                  "orderType": "0",
+                  "startTime": "0",
+                  "endTime": "0",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                },
+                {
+                  "offerer": "0x0000000000000000000000000000000000000000",
+                  "zone": "0x0000000000000000000000000000000000000000",
+                  "offer": [],
+                  "consideration": [],
+                  "orderType": "0",
+                  "startTime": "0",
+                  "endTime": "0",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                }
+              ],
+              [
+                {
+                  "offerer": "0x0000000000000000000000000000000000000000",
+                  "zone": "0x0000000000000000000000000000000000000000",
+                  "offer": [],
+                  "consideration": [],
+                  "orderType": "0",
+                  "startTime": "0",
+                  "endTime": "0",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                },
+                {
+                  "offerer": "0x0000000000000000000000000000000000000000",
+                  "zone": "0x0000000000000000000000000000000000000000",
+                  "offer": [],
+                  "consideration": [],
+                  "orderType": "0",
+                  "startTime": "0",
+                  "endTime": "0",
+                  "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "salt": "0",
+                  "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                  "counter": "0"
+                }
+              ]
+            ]
+          ]
+        ]
+      }
+    },
+    "domainHash":  "0x94c78e94e233546655365725a17a437f48bb870b898e35b894da4a0887172dc2",
+    "messageHash": "0x6141febc9edb34347a91729533c7c8d3a934fdc34429a0ef9497d5d22664321c",
+    "digest": "0x9478f43bbeeb2da013ff8595f19a3cb803b41c72596dc0faa6ff1d1b8a70c9f8"
+  },
+  {
+    "name": "five-dimensional-fixed-size-array",
+    "typedData": {
+      "domain": {
+        "name": "ImmutableSeaport",
+        "version": "1.5",
+        "chainId": 31337,
+        "verifyingContract": "0x3870289A34bba912a05B2c0503F7484dD18d2f6F"
+      },
+      "primaryType": "BulkOrder",
+      "types": {
+        "BulkOrder": [
+          {
+            "name": "tree",
+            "type": "OrderComponents[2][2][2][2][2]"
+          }
+        ],
+        "OrderComponents": [
+          {
+            "name": "offerer",
+            "type": "address"
+          },
+          {
+            "name": "zone",
+            "type": "address"
+          },
+          {
+            "name": "offer",
+            "type": "OfferItem[]"
+          },
+          {
+            "name": "consideration",
+            "type": "ConsiderationItem[]"
+          },
+          {
+            "name": "orderType",
+            "type": "uint8"
+          },
+          {
+            "name": "startTime",
+            "type": "uint256"
+          },
+          {
+            "name": "endTime",
+            "type": "uint256"
+          },
+          {
+            "name": "zoneHash",
+            "type": "bytes32"
+          },
+          {
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "name": "conduitKey",
+            "type": "bytes32"
+          },
+          {
+            "name": "counter",
+            "type": "uint256"
+          }
+        ],
+        "OfferItem": [
+          {
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "name": "identifierOrCriteria",
+            "type": "uint256"
+          },
+          {
+            "name": "startAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "endAmount",
+            "type": "uint256"
+          }
+        ],
+        "ConsiderationItem": [
+          {
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "name": "identifierOrCriteria",
+            "type": "uint256"
+          },
+          {
+            "name": "startAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "endAmount",
+            "type": "uint256"
+          },
+          {
+            "name": "recipient",
+            "type": "address"
+          }
+        ],
+        "EIP712Domain": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "type": "string"
+          },
+          {
+            "name": "chainId",
+            "type": "uint256"
+          },
+          {
+            "name": "verifyingContract",
+            "type": "address"
+          }
+        ]
+      },
+      "message": {
+        "tree": [
+          [
+            [
+              [
+                [
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0xad1cd95e33df638d",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "1",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0x8c46499a985556e7",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ],
+                [
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "2",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0xf113dfcd2fd90f34",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "3",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0x86e05a39d63439ab",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ]
+              ],
+              [
+                [
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "4",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0xea0549310e1fcf98",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "5",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0x3c7ebf9ef6b22665",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ],
+                [
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "6",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0x6d8a0266cd32c3cf",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "7",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0x5508a5f8c60e761f",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ]
+              ]
+            ],
+            [
+              [
+                [
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "8",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0xde53a72c803e4780",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "9",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0xb4ad240444cd7c1d",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ],
+                [
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "10",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0xd5559fcc7192a0e8",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "11",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0xdde06bfaf059bf21",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ]
+              ],
+              [
+                [
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "12",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0x02f0b40bd92ec30d",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "13",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0xa2e93fa3d6add8ef",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ],
+                [
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "14",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0x1c9502d5e53ca013",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "15",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0x32c9f5cdbbcf0a0e",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ]
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                [
+                  {
+                    "offerer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                    "zone": "0x84c7fea5b8c328db68632a3bdda3aadab7d36e66",
+                    "offer": [
+                      {
+                        "itemType": "2",
+                        "token": "0xd28f3246f047efd4059b24fa1fa587ed9fa3e77f",
+                        "identifierOrCriteria": "16",
+                        "startAmount": "1",
+                        "endAmount": "1"
+                      }
+                    ],
+                    "consideration": [
+                      {
+                        "itemType": "0",
+                        "token": "0x0000000000000000000000000000000000000000",
+                        "identifierOrCriteria": "0",
+                        "startAmount": "1000000",
+                        "endAmount": "1000000",
+                        "recipient": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                      }
+                    ],
+                    "orderType": "2",
+                    "startTime": "1721798656",
+                    "endTime": "1784870656",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0x9cc16b772ab421d8",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ],
+                [
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ]
+              ],
+              [
+                [
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ],
+                [
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ]
+              ]
+            ],
+            [
+              [
+                [
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ],
+                [
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ]
+              ],
+              [
+                [
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ],
+                [
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  },
+                  {
+                    "offerer": "0x0000000000000000000000000000000000000000",
+                    "zone": "0x0000000000000000000000000000000000000000",
+                    "offer": [],
+                    "consideration": [],
+                    "orderType": "0",
+                    "startTime": "0",
+                    "endTime": "0",
+                    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "salt": "0",
+                    "conduitKey": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "counter": "0"
+                  }
+                ]
+              ]
+            ]
+          ]
+        ]
+      }
+    },
+    "domainHash":  "0x94c78e94e233546655365725a17a437f48bb870b898e35b894da4a0887172dc2",
+    "messageHash": "0x127b8c1a34e217116438ea08d10a5e6679ec57fd553ba64891f24500f12dada0",
+    "digest": "0xc319cb3f3ad00993bd33741486db2c9dec09fe8afc1757697cb7ce2b35e1b8e1"
+  },
+  {
+    "name": "primitive-fixed-size-array",
+    "typedData": {
+      "domain": {
+        "name": "Moo é🚀oM o     MMoéMé🚀MéMéM",
+        "chainId": "900"
+      },
+      "primaryType": "Struct5",
+      "types": {
+        "Struct5": [
+          {
+            "name": "param2",
+            "type": "string[3][3]"
+          }
+        ],
+        "EIP712Domain": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ]
+      },
+      "message": {
+        "param2": [
+          [
+            "Moo é🚀MMo 🚀🚀MM oéoooéé",
+            "Moo é🚀 éo🚀 🚀oéoMo",
+            "Moo é🚀oééoéM oMé Moéoo oo M MMoééoooo🚀M🚀o🚀oéMo oo é Moo ooo oo🚀 "
+          ],
+          [
+            "Moo é🚀o🚀ooéMMooooMo oo  o🚀 M🚀Mooo oé🚀o🚀oéoM 🚀M oéo🚀 🚀🚀  🚀o🚀   M",
+            "Moo é🚀oéé🚀ooéo ooooM🚀🚀éo🚀🚀🚀ooé🚀 éooM🚀oooooMoo Mo🚀ooooMM 🚀 🚀",
+            "Moo é🚀oo🚀M o🚀oo🚀éoMoooM  oM M🚀ooMM🚀 éo MooMM  éooo"
+          ],
+          [
+            "Moo é🚀MMMééo oM o🚀 🚀🚀 Mo o🚀éo🚀oMoé éé oo🚀éé🚀Méoé🚀🚀oéoo 🚀",
+            "Moo é🚀 🚀M",
+            "Moo é🚀oo🚀Mo🚀🚀oMo🚀M🚀 o  MMoo   ééMoé MoMoMMooééoo🚀 éo"
+          ]
+        ]
+      }
+    },
+    "domainHash":  "0x5247656f531410c29fada51024987197407dd7082c1280d87ab649e5ab05a646",
+    "messageHash": "0xa008f077c5a31e71f01d75fbc91d0fdd4c79d37d634a35e99e528d46ad199417",
+    "digest": "0x42bfc8f80f73b02a800f2cf5f3b9b96c6774a43c706758c8f34f1fabf946b001"
+  },
+  {
+    "name": "variable-sized-array",
+    "typedData": {
+      "domain": {
+        "name": "ImmutableSeaport",
+        "chainId": "31337",
+        "verifyingContract": "0x3870289A34bba912a05B2c0503F7484dD18d2f6F"
+      },
+      "primaryType": "CancelPayload",
+      "types": {
+        "CancelPayload": [
+          {
+            "name": "orders",
+            "type": "Order[]"
+          }
+        ],
+        "Order": [
+          {
+            "name": "id",
+            "type": "string"
+          }
+        ],
+        "EIP712Domain": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "chainId",
+            "type": "uint256"
+          },
+          {
+            "name": "verifyingContract",
+            "type": "address"
+          }
+        ]
+      },
+      "message": {
+        "orders": [
+          {
+            "id": "0190e908-3569-b173-91d8-00b8d1f348c6"
+          }
+        ]
+      }
+    },
+    "domainHash":  "0x37856d6168ec1ad4ae7e76775b7a965e63484ce7265f56fb4e63576464a1f53c",
+    "messageHash": "0x8ff8e2eb9e5a1974689105e77129019e922ada8a69b64d7f6e6a4d542a0ae6e4",
+    "digest": "0xbdd0eb3dd7563b92d43a21dea664c6bdcdc5e4ba440601bc03d0d70549e9b564"
+  }
+]

--- a/signer/core/apitypes/types_test.go
+++ b/signer/core/apitypes/types_test.go
@@ -22,8 +22,9 @@ func TestIsPrimitive(t *testing.T) {
 	t.Parallel()
 	// Expected positives
 	for i, tc := range []string{
-		"int24", "int24[]", "uint88", "uint88[]", "uint", "uint[]", "int256", "int256[]",
-		"uint96", "uint96[]", "int96", "int96[]", "bytes17[]", "bytes17",
+		"int24", "int24[]", "int[]", "int[2]", "uint88", "uint88[]", "uint", "uint[]", "uint[2]", "int256", "int256[]",
+		"uint96", "uint96[]", "int96", "int96[]", "bytes17[]", "bytes17", "address[2]", "bool[4]", "string[5]", "bytes[2]",
+		"bytes32", "bytes32[]", "bytes32[4]",
 	} {
 		if !isPrimitiveTypeValid(tc) {
 			t.Errorf("test %d: expected '%v' to be a valid primitive", i, tc)
@@ -36,6 +37,97 @@ func TestIsPrimitive(t *testing.T) {
 	} {
 		if isPrimitiveTypeValid(tc) {
 			t.Errorf("test %d: expected '%v' to not be a valid primitive", i, tc)
+		}
+	}
+}
+
+func TestType_IsArray(t *testing.T) {
+	t.Parallel()
+	// Expected positives
+	for i, tc := range []Type{
+		{
+			Name: "type1",
+			Type: "int24[]",
+		},
+		{
+			Name: "type2",
+			Type: "int24[2]",
+		},
+		{
+			Name: "type3",
+			Type: "int24[2][2][2]",
+		},
+	} {
+		if !tc.isArray() {
+			t.Errorf("test %d: expected '%v' to be an array", i, tc)
+		}
+	}
+	// Expected negatives
+	for i, tc := range []Type{
+		{
+			Name: "type1",
+			Type: "int24",
+		},
+		{
+			Name: "type2",
+			Type: "uint88",
+		},
+		{
+			Name: "type3",
+			Type: "bytes32",
+		},
+	} {
+		if tc.isArray() {
+			t.Errorf("test %d: expected '%v' to not be an array", i, tc)
+		}
+	}
+}
+
+func TestType_TypeName(t *testing.T) {
+	t.Parallel()
+
+	for i, tc := range []struct {
+		Input    Type
+		Expected string
+	}{
+		{
+			Input: Type{
+				Name: "type1",
+				Type: "int24[]",
+			},
+			Expected: "int24",
+		},
+		{
+			Input: Type{
+				Name: "type2",
+				Type: "int26[2][2][2]",
+			},
+			Expected: "int26",
+		},
+		{
+			Input: Type{
+				Name: "type3",
+				Type: "int24",
+			},
+			Expected: "int24",
+		},
+		{
+			Input: Type{
+				Name: "type4",
+				Type: "uint88",
+			},
+			Expected: "uint88",
+		},
+		{
+			Input: Type{
+				Name: "type5",
+				Type: "bytes32[2]",
+			},
+			Expected: "bytes32",
+		},
+	} {
+		if tc.Input.typeName() != tc.Expected {
+			t.Errorf("test %d: expected typeName value of '%v' to be '%v'", i, tc.Input, tc.Expected)
 		}
 	}
 }


### PR DESCRIPTION
The [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) specification supports encoding fixed size and dynamic sized arrays.

From the spec,

The reference types are arrays and structs. Arrays are either fixed size or dynamic and denoted by Type[n] or Type[] respectively. Structs are references to other structs by their name. The standard supports recursive struct types.

Unfortunately go-ethereum in its current form doesn't fully comply with the [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) standard because the signer module currently doesn't support encoding fixed size array datatypes.

This PR fixes the gap by extending the current signer module encoding logic to support fixed size arrays of primitive and custom types.

This PR was originally reviewed / merged in the parent of this repository,
* https://github.com/jasonzwli/go-ethereum/pull/3
* https://github.com/jasonzwli/go-ethereum/pull/4